### PR TITLE
Use wc@/wc! and d@/d! for @c/!c and l@/l!

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,13 +106,13 @@ The primitives:
 
 | WORD      | STACK        | DESCRIPTION |
 |:--        |:--           |:-- |
-| (lit)     | (--W)        | W: WORD-CODE for LIT primitive |
-| (jmp)     | (--W)        | W: WORD-CODE for JMP primitive |
-| (jmpz)    | (--W)        | W: WORD-CODE for JMPZ primitive |
-| (jmpnz)   | (--W)        | W: WORD-CODE for JMPNZ primitive |
-| (njmpz)   | (--W)        | W: WORD-CODE for NJMPZ primitive |
-| (njmpnz)  | (--W)        | W: WORD-CODE for NJMPNZ primitive |
-| (exit)    | (--W)        | W: WORD-CODE for EXIT primitive |
+| (lit)     | (--WC)       | WC: WORD-CODE for LIT primitive |
+| (jmp)     | (--WC)       | WC: WORD-CODE for JMP primitive |
+| (jmpz)    | (--WC)       | WC: WORD-CODE for JMPZ primitive |
+| (jmpnz)   | (--WC)       | WC: WORD-CODE for JMPNZ primitive |
+| (njmpz)   | (--WC)       | WC: WORD-CODE for NJMPZ primitive |
+| (njmpnz)  | (--WC)       | WC: WORD-CODE for NJMPNZ primitive |
+| (exit)    | (--WC)       | WC: WORD-CODE for EXIT primitive |
 | exit      | (--)         | EXIT word |
 | dup       | (X--X X)     | Duplicate TOS (Top-Of-Stack) |
 | swap      | (X Y--Y X)   | Swap TOS and NOS (Next-On-Stack) |

--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ The primitives:
 | over      | (N X--N X N) | Push NOS |
 | @         | (A--N)       | N: the CELL at absolute address A |
 | c@        | (A--C)       | C: the CHAR at absolute address A |
-| l@        | (A--L)       | L: the DWORD at absolute address A |
-| @c        | (N--W)       | Fetch 32-bit value W from CODE slot N |
+| d@        | (A--D)       | D: the DWORD at absolute address A |
+| wc@       | (N--W)       | Fetch word-code W from CODE slot N |
 | !         | (N A--)      | Store CELL N to absolute address A |
 | c!        | (C A--)      | Store CHAR C to absolute address A |
-| l!        | (L A--)      | Store DWORD L to absolute address A |
-| wc!       | (W N--)      | Store 32-bit value W to CODE slot N |
+| d!        | (D A--)      | Store DWORD D to absolute address A |
+| wc!       | (W N--)      | Store word-code W to CODE slot N |
 | +         | (X Y--N)     | N: X + Y |
 | -         | (X Y--N)     | N: X - Y |
 | *         | (X Y--N)     | N: X * Y |

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ A `CELL` is either 32-bits or 64-bits, depending on the target system.
 
 ## C4 memory areas
 C4 provides two memory areas:
-- The `code` area can store up to $1FFFFFFF 32-bit WORD-CODEs. (see `code-sz`).
+- The CODE area can store up to $1FFFFFFF 32-bit WORD-CODEs. (see `code-sz`).
   - **NOTE**: CODE slots 0-25 (`0 wc@ .. 25 wc@`) are reserved for C4 system values.
   - **NOTE**: CODE slots 25-75 (`25 wc@` .. `75 wc@`) are unused by C4.
   - **NOTE**: These are free for the application to use as desired.
   - **NOTE**: Use `wc@` and `wc!` to get and set WORD-CODE values in the code area.
   - `here` is an offset into the code area.
-- The `vars` area can store up to CELL bytes (see `vars-sz`).
+- The VARS area can store up to CELL bytes (see `vars-sz`).
   - `vhere` is the address of the first free byte the vars area.
   - `last` is an offset into the vars area.
 - Use `->code` and `->vars` to turn an offset into an address.
@@ -174,22 +174,21 @@ The primitives:
 | addword   | (--)         | Add the next word to the dictionary |
 | timer     | (--N)        | N: Current time |
 | see X     | (--)         | Output the definition of word X |
-| ztype     | (SZ--)       | Print string at SZ (uncounted, unformatted) |
-| ftype     | (SZ--)       | Print string at SZ (uncounted, formatted) |
-| s-cpy     | (D S--D)     | Copy string S to D, counted |
+| ztype     | (SZ--)       | Print string at SZ (unformatted) |
+| ftype     | (SZ--)       | Print string at SZ (formatted) |
+| s-cpy     | (D S--D)     | Copy string S to D |
 | s-eq      | (D S--F)     | F: 1 if string S is equal to D (case sensitive) |
 | s-eqi     | (D S--F)     | F: 1 if string S is equal to D (NOT case sensitive) |
 | s-len     | (S--N)       | N: Length of string S |
-| z"        | (--)         | -COMPILE: Create uncounted string SZ to next `"` |
+| z"        | (--)         | -COMPILE: Create string SZ to next `"` |
 |           | (--S)        | -RUN: push address S of string |
 | ."        | (--)         | -COMPILE: execute `z"`, compile `ftype` |
 |           | (--)         | -RUN: `ftype` on string |
 | find      | (--XT A)     | XT: Execution Token, A: Dict Entry address (0 0 if not found) |
 | loaded?   | (XT A--)     | Stops current load if A <> 0 (see `find`) |
 | fopen     | (NM MD--FH)  | NM: File Name, MD: Mode, FH: File Handle (0 if error/not found) |
-|           |              |     NOTE: NM and MD are uncounted, use `z"` |
 | fclose    | (FH--)       | FH: File Handle to close |
-| fdelete   | (NM--)       | NM: File Name to delere |
+| fdelete   | (NM--)       | NM: File Name to delete |
 | fread     | (A N FH--X)  | A: Buffer, N: Size, FH: File Handle, X: num chars read |
 | fwrite    | (A N FH--X)  | A: Buffer, N: Size, FH: File Handle, X: num chars written |
 | fgets     | (A N FH--X)  | A: Buffer, N: Size, X: num chars read (0 if EOF/Error) |

--- a/README.md
+++ b/README.md
@@ -170,6 +170,8 @@ The primitives:
 | emit      | (C--)        | Output char C |
 | :         | (--)         | Create a new word, set STATE=1 |
 | ;         | (--)         | Compile EXIT, set STATE=0 |
+| lit,      | (N--)        | Compile a push of number N |
+| next-wd   | (--L)        | L: length of the next word from the input stream |
 | immediate | (--)         | Mark the last created word as IMMEDIATE |
 | inline    | (--)         | Mark the last created word as INLINE |
 | outer     | (S--)        | Send string S to the C4 outer interpreter |

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ A `CELL` is either 32-bits or 64-bits, depending on the target system.
 ## C4 memory areas
 C4 provides three memory areas:
 - The `code` area can store up to $1FFFFFFF 32-bit WORD-CODEs, 32-bit index. (see `code-sz`).
-  - **NOTE**: CODE slots 0-25 (`0 @c .. 25 @c`) are reserved for C4 system values.
-  - **NOTE**: CODE slots 25-75 (`25 @c` .. `75 @c`) are unused by C4.
+  - **NOTE**: CODE slots 0-25 (`0 wc@ .. 25 wc@`) are reserved for C4 system values.
+  - **NOTE**: CODE slots 25-75 (`25 wc@` .. `75 wc@`) are unused by C4.
   - **NOTE**: These are free for the application to use as desired.
-  - **NOTE**: Use `@c` and `!c` to get and set 32-bit values in the code area.
+  - **NOTE**: Use `wc@` and `wc!` to get and set 32-bit values in the code area.
 - The `vars` area can store up to CELL bytes (see `vars-sz`).
 - - `vhere` is the address of the first free byte the vars area.
 - The `dict` area can can be any size, 32-bit index (see `dict-sz`).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A `WORD-CODE` is a 32-bit unsigned number. <br/>
 Primitives are assigned numbers sequentially from 0 to `BYE`. <br/>
 If a WORD-CODE is less than or equal to `BYE`, it is a primitive. <br/>
 If the top 3 bits are set ($Exxxxxxx), it is a 29-bit unsigned literal. <br/>
-If it is greater than `BYE`, it is the code address of a word to execute. <br/>
+If it is between `BYE`, and $E0000000, it is the code address of a word to execute. <br/>
 
 ## CELLs in C4
 A `CELL` is either 32-bits or 64-bits, depending on the target system.
@@ -15,18 +15,17 @@ A `CELL` is either 32-bits or 64-bits, depending on the target system.
 - Windows 64-bit (x64): a CELL is 64-bits.
 
 ## C4 memory areas
-C4 provides three memory areas:
-- The `code` area can store up to $1FFFFFFF 32-bit WORD-CODEs, 32-bit index. (see `code-sz`).
+C4 provides two memory areas:
+- The `code` area can store up to $1FFFFFFF 32-bit WORD-CODEs. (see `code-sz`).
   - **NOTE**: CODE slots 0-25 (`0 wc@ .. 25 wc@`) are reserved for C4 system values.
   - **NOTE**: CODE slots 25-75 (`25 wc@` .. `75 wc@`) are unused by C4.
   - **NOTE**: These are free for the application to use as desired.
-  - **NOTE**: Use `wc@` and `wc!` to get and set 32-bit values in the code area.
+  - **NOTE**: Use `wc@` and `wc!` to get and set WORD-CODE values in the code area.
+  - `here` is an offset into the code area.
 - The `vars` area can store up to CELL bytes (see `vars-sz`).
-- - `vhere` is the address of the first free byte the vars area.
-- The `dict` area can can be any size, 32-bit index (see `dict-sz`).
-- `here` is an offset into the code area.
-- `last` is an offset into the dict area.
-- Use `->code` and `->dict` to turn an offset into an address.
+  - `vhere` is the address of the first free byte the vars area.
+  - `last` is an offset into the vars area.
+- Use `->code` and `->vars` to turn an offset into an address.
 
 | WORD       | STACK   | DESCRIPTION |
 |:--         |:--      |:--          |
@@ -62,9 +61,9 @@ For example `: ascii dup dup dup ." char %c, decimal #%d, binary: %%%b, hex: $%x
 | %[x]   | (--)  | EMIT [x]. |
 
 ## The A stack
-C4 includes an `a` stack. <br/>
-This is somewhat similar to ColorForth's operations for 'a', but in C4, it is a stack.<br/>
-The size of the `a` stack is configurable (see `tstk-sz`).<br/>
+C4 includes an A stack. <br/>
+This is somewhat similar to MachineForth's operations for 'a', but in C4, it is a stack.<br/>
+The size of the A stack is configurable (see `tstk-sz`).<br/>
 
 | WORD  | STACK  | DESCRIPTION |
 |:--    |:--     |:-- |
@@ -76,7 +75,7 @@ The size of the `a` stack is configurable (see `tstk-sz`).<br/>
 | `a>`  | (--N)  | Pop N from the A stack. |
 
 ## The T Stack
-C4 includes a `t` stack, with same ops as the `a` stack. <br/>
+C4 includes a T stack, with same ops as the T stack. <br/>
 Note that there are also additional words for the return stack. <br/>
 
 | WORD  | STACK  | DESCRIPTION |
@@ -94,10 +93,9 @@ Stack effect notation conventions:
 | TERM     | DESCRIPTION |
 |:--       |:-- |
 | SZ/NM/MD | String, uncounted, NULL terminated |
-| SC/D/S   | String, counted, NULL terminated |
 | A        | Address |
 | C        | Number, 8-bits |
-| W        | Number, 32-bits |
+| WC       | WORD-CODE, 32-bits |
 | N/X/Y    | Number, CELL sized |
 | F        | Flag: 0 mean0 false, <>0 means true |
 | R        | Register number |
@@ -123,11 +121,11 @@ The primitives:
 | @         | (A--N)       | N: the CELL at absolute address A |
 | c@        | (A--C)       | C: the CHAR at absolute address A |
 | d@        | (A--D)       | D: the DWORD at absolute address A |
-| wc@       | (N--W)       | Fetch word-code W from CODE slot N |
+| wc@       | (N--WC)      | Fetch word-code WC from CODE slot N |
 | !         | (N A--)      | Store CELL N to absolute address A |
 | c!        | (C A--)      | Store CHAR C to absolute address A |
 | d!        | (D A--)      | Store DWORD D to absolute address A |
-| wc!       | (W N--)      | Store word-code W to CODE slot N |
+| wc!       | (WC N--)     | Store word-code WC to CODE slot N |
 | +         | (X Y--N)     | N: X + Y |
 | -         | (X Y--N)     | N: X - Y |
 | *         | (X Y--N)     | N: X * Y |
@@ -172,8 +170,8 @@ The primitives:
 | ;         | (--)         | Compile EXIT, set STATE=0 |
 | immediate | (--)         | Mark the last created word as IMMEDIATE |
 | inline    | (--)         | Mark the last created word as INLINE |
-| addword   | (--)         | -COMPILE: Add the next word to the dictionary |
-|           | (--A)        | -RUN: A: current VHERE address |
+| outer     | (S--)        | Send string S to the C4 outer interpreter |
+| addword   | (--)         | Add the next word to the dictionary |
 | timer     | (--N)        | N: Current time |
 | see X     | (--)         | Output the definition of word X |
 | ztype     | (SZ--)       | Print string at SZ (uncounted, unformatted) |
@@ -183,9 +181,11 @@ The primitives:
 | s-eqi     | (D S--F)     | F: 1 if string S is equal to D (NOT case sensitive) |
 | s-len     | (S--N)       | N: Length of string S |
 | z"        | (--)         | -COMPILE: Create uncounted string SZ to next `"` |
-|           | (--SZ)       | -RUN: push address SZ of string |
+|           | (--S)        | -RUN: push address S of string |
 | ."        | (--)         | -COMPILE: execute `z"`, compile `ftype` |
 |           | (--)         | -RUN: `ftype` on string |
+| find      | (--XT A)     | XT: Execution Token, A: Dict Entry address (0 0 if not found) |
+| loaded?   | (XT A--)     | Stops current load if A <> 0 (see `find`) |
 | fopen     | (NM MD--FH)  | NM: File Name, MD: Mode, FH: File Handle (0 if error/not found) |
 |           |              |     NOTE: NM and MD are uncounted, use `z"` |
 | fclose    | (FH--)       | FH: File Handle to close |
@@ -196,10 +196,7 @@ The primitives:
 | include X | (--)         | Load file named X (X: next word) |
 | load      | (N--)        | N: Block number to load (file named "block-NNN.fth") |
 | load-next | (N--)        | Close the current block and load block N next |
-| loaded?   | (W A--)      | Stops current load if A <> 0 (see `find`) |
-| to-string | (N--SC)      | Convert N to string SC in the current BASE |
-| find      | (--W A)      | W: Execution Token, A: Dict Entry address (0 0 if not found) |
-| system    | (SC--)       | PC ONLY: SC: String to send to `system()` |
+| system    | (S--)        | PC ONLY: S: String to send to `system()` |
 | bye       | (--)         | PC ONLY: Exit C4 |
 
 ## C4 default words

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The primitives:
 | !         | (N A--)      | Store CELL N to absolute address A |
 | c!        | (C A--)      | Store CHAR C to absolute address A |
 | l!        | (L A--)      | Store DWORD L to absolute address A |
-| !c        | (W N--)      | Store 32-bit value W to CODE slot N |
+| wc!       | (W N--)      | Store 32-bit value W to CODE slot N |
 | +         | (X Y--N)     | N: X + Y |
 | -         | (X Y--N)     | N: X - Y |
 | *         | (X Y--N)     | N: X * Y |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A `CELL` is either 32-bits or 64-bits, depending on the target system.
 C4 provides two memory areas:
 - The CODE area can store up to $1FFFFFFF 32-bit WORD-CODEs. (see `code-sz`).
   - **NOTE**: CODE slots 0-25 (`0 wc@ .. 25 wc@`) are reserved for C4 system values.
-  - **NOTE**: CODE slots 25-75 (`25 wc@` .. `75 wc@`) are unused by C4.
+  - **NOTE**: CODE slots 26-75 (`26 wc@` .. `75 wc@`) are unused by C4.
   - **NOTE**: These are free for the application to use as desired.
   - **NOTE**: Use `wc@` and `wc!` to get and set WORD-CODE values in the code area.
   - `here` is an offset into the code area.
@@ -75,7 +75,7 @@ The size of the A stack is configurable (see `tstk-sz`).<br/>
 | `a>`  | (--N)  | Pop N from the A stack. |
 
 ## The T Stack
-C4 includes a T stack, with same ops as the T stack. <br/>
+C4 includes a T stack, with same ops as the A stack. <br/>
 Note that there are also additional words for the return stack. <br/>
 
 | WORD  | STACK  | DESCRIPTION |
@@ -180,7 +180,7 @@ The primitives:
 | s-eq      | (D S--F)     | F: 1 if string S is equal to D (case sensitive) |
 | s-eqi     | (D S--F)     | F: 1 if string S is equal to D (NOT case sensitive) |
 | s-len     | (S--N)       | N: Length of string S |
-| z"        | (--)         | -COMPILE: Create string SZ to next `"` |
+| z"        | (--)         | -COMPILE: Create string S to next `"` |
 |           | (--S)        | -RUN: push address S of string |
 | ."        | (--)         | -COMPILE: execute `z"`, compile `ftype` |
 |           | (--)         | -RUN: `ftype` on string |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # c4: a Forth system inspired by MachineForth and Tachyon
 
 In C4, a program is a sequence of WORD-CODEs. <br/>
-A `WORD-CODE` is a 32-bit unsigned number. <br/>
+A WORD-CODE is a 32-bit unsigned number. <br/>
 Primitives are assigned numbers sequentially from 0 to `BYE`. <br/>
 If a WORD-CODE is less than or equal to `BYE`, it is a primitive. <br/>
 If the top 3 bits are set ($Exxxxxxx), it is a 29-bit unsigned literal. <br/>
@@ -55,8 +55,8 @@ For example `: ascii dup dup dup ." char %c, decimal #%d, binary: %%%b, hex: $%x
 | %i     | (N--) | Print TOS in the current base. |
 | %n     | (--)  | Print CR/LF (13/10). |
 | %q     | (--)  | EMIT `"` (#34). |
-| %s     | (A--) | Print TOS as a string (uncounted, formatted). |
-| %S     | (A--) | Print TOS as a string (uncounted, unformatted). |
+| %s     | (A--) | Print TOS as a string (formatted). |
+| %S     | (A--) | Print TOS as a string (unformatted). |
 | %x     | (N--) | Print TOS in base 16. |
 | %[x]   | (--)  | EMIT [x]. |
 
@@ -73,6 +73,7 @@ The size of the A stack is configurable (see `tstk-sz`).<br/>
 | `a@+` | (--N)  | N: copy of A-TOS, then increment A-TOS. |
 | `a@-` | (--N)  | N: copy of A-TOS, then decrement A-TOS. |
 | `a>`  | (--N)  | Pop N from the A stack. |
+| adrop | ( -- ) | Drop A-TOS |
 
 ## The T Stack
 C4 includes a T stack, with same ops as the A stack. <br/>
@@ -86,6 +87,7 @@ Note that there are also additional words for the return stack. <br/>
 | `t@+` | (--N)  | N: copy of T-TOS, then increment T-TOS. |
 | `t@-` | (--N)  | N: copy of T-TOS, then decrement T-TOS. |
 | `t>`  | (--N)  | Pop N from the T stack. |
+| tdrop | ( -- ) | Drop T-TOS |
 
 ## C4 WORD-CODE primitives
 Stack effect notation conventions:
@@ -121,11 +123,11 @@ The primitives:
 | @         | (A--N)       | N: the CELL at absolute address A |
 | c@        | (A--C)       | C: the CHAR at absolute address A |
 | d@        | (A--D)       | D: the DWORD at absolute address A |
-| wc@       | (N--WC)      | Fetch word-code WC from CODE slot N |
+| wc@       | (N--WC)      | WC: the WORD-CODE in CODE slot N |
 | !         | (N A--)      | Store CELL N to absolute address A |
 | c!        | (C A--)      | Store CHAR C to absolute address A |
 | d!        | (D A--)      | Store DWORD D to absolute address A |
-| wc!       | (WC N--)     | Store word-code WC to CODE slot N |
+| wc!       | (WC N--)     | Store WORD-CODE WC to CODE slot N |
 | +         | (X Y--N)     | N: X + Y |
 | -         | (X Y--N)     | N: X - Y |
 | *         | (X Y--N)     | N: X * Y |
@@ -141,9 +143,9 @@ The primitives:
 | or        | (X Y--N)     | N: X OR  Y |
 | xor       | (X Y--N)     | N: X XOR Y |
 | com       | (X--Y)       | Y: X with all bits flipped (complement) |
-| for       | (N--)        | Begin FOR loop with bounds 0 and N. |
+| for       | (N--)        | Begin FOR loop with bounds 0 and N-1. |
 | i         | (--I)        | N: Current FOR loop index. |
-| next      | (--)         | Increment I. If I < N, start loop again, else exit. |
+| next      | (--)         | Increment I. If I >= N, exit, else start loop again. |
 | >r        | (N--)        | Push N onto the return stack |
 | r!        | (N--)        | Set R-TOS to N |
 | r@        | (--N)        | N: copy of R-TOS |
@@ -174,8 +176,8 @@ The primitives:
 | addword   | (--)         | Add the next word to the dictionary |
 | timer     | (--N)        | N: Current time |
 | see X     | (--)         | Output the definition of word X |
-| ztype     | (SZ--)       | Print string at SZ (unformatted) |
-| ftype     | (SZ--)       | Print string at SZ (formatted) |
+| ztype     | (S--)        | Print string at S (unformatted) |
+| ftype     | (S--)        | Print string at S (formatted) |
 | s-cpy     | (D S--D)     | Copy string S to D |
 | s-eq      | (D S--F)     | F: 1 if string S is equal to D (case sensitive) |
 | s-eqi     | (D S--F)     | F: 1 if string S is equal to D (NOT case sensitive) |

--- a/block-006.fth
+++ b/block-006.fth
@@ -2,18 +2,18 @@
 
 find dump loaded?
 
-: .2 <# # #s #> ztype ;
+: .X ( num width-- ) >r <# r> 1- for # next #s #> ztype ;
+: .2 2 .X ;   : .3 3 .X ;   : .4 4 .X ;
 : .hex base@ >t hex .2 t> base! ;
 : .bin base@ >t binary (.) t> base! ;
-: t1 ( ch-- ) dup 32 < over 126 > or if drop '.' then emit ;
-: t2 ( a-- ) $10 for dup c@ t1 1+ next drop ;
-: dump ( a n-- ) swap >a 0 >t
+: a-emit ( ch-- ) dup 32 < over 126 > or if drop '.' then emit ;
+: t2 ( addr-- ) $10 for dup c@ a-emit 1+ next drop ;
+: dump ( addr n-- ) swap >a 0 >t
    for 0 t@ = if a@ ." %n%x: " then
        @a+ .hex space t@+ $0f = if ."    " 0 t! a@ $10 - t2 then
    next atdrop ;
-: lshift for 2* next ;
-: rshift for 2/ next ;
-
+: lshift ( n1 count--n2 ) for 2* next ;
+: rshift ( n1 count--n2 ) for 2/ next ;
 
 
 

--- a/block-007.fth
+++ b/block-007.fth
@@ -1,0 +1,32 @@
+( Locals: example ... )
+( : mx+b [[ m x b--n]] +locs  s3 s2 s1  r1 r2 * r3 +  -locs ; )
+
+45 cells var ls-stk
+vhere const ls-basemax
+5 cells allot
+cell var ls-base
+: t0   ( index--addr ) [ cell lit, ] * ls-base @ + ;
+: ls!  ( num index-- ) t0 ! ;
+: ls@  ( index--num )  t0 @ ;
+: ls@+ ( index--num )  t0 dup >r @ dup 1+ r> ! ;
+: ls@- ( index--num )  t0 dup >r @ dup 1- r> ! ;
+: ls-reset ls-stk ls-base ! ;
+: +locs ( -- ) ls-base @ [ 5 cells lit, ] + ls-basemax min ls-base ! ;
+: -locs ( -- ) ls-base @ [ 5 cells lit, ] - ls-stk     max ls-base ! ;
+
+: s1 0 ls! ;  : r1 0 ls@ ;  : r1+ 0 ls@+ ;  : r1- 0 ls@- ;
+: s2 1 ls! ;  : r2 1 ls@ ;  : r2+ 1 ls@+ ;  : r2- 1 ls@- ;
+: s3 2 ls! ;  : r3 2 ls@ ;  : r3+ 2 ls@+ ;  : r3- 2 ls@- ;
+: s4 3 ls! ;  : r4 3 ls@ ;  : r4+ 3 ls@+ ;  : r4- 3 ls@- ;
+: s5 4 ls! ;  : r5 4 ls@ ;  : r5+ 4 ls@+ ;  : r5- 4 ls@- ;
+
+ls-reset
+
+
+
+
+
+
+
+
+

--- a/block-020.fth
+++ b/block-020.fth
@@ -28,5 +28,5 @@ block-sz var work
 : mv-lt 0 -1 mv ;  : mv-rt 0 1 mv ;  : mv-up -1 0 mv ;  : mv-dn 1 0 mv ;
 : >row/col ( r c-- ) >col >row ;
 21 26 thru
-: ed ( -- ) ed-init ed-load cls ed-loop ;
+: ed ( -- ) ed-init rl cls ed-loop ;
 : edit ( blk-- ) >blk ed ;

--- a/block-020.fth
+++ b/block-020.fth
@@ -21,7 +21,7 @@ block-sz var work
 : nt-lines rows for i nt-line next ;
 : ->cur   col 2+ row 2+ ->cr cur-on ;
 : ->foot  1 rows 3 + ->cr ;
-: ->cmd   ->foot cr ;
+: ->cmd   ->foot cr clr-eol ;
 : norm-row ( x-- )  row + 0 max max-row    min >row ;
 : norm-col ( x-- )  col + 0 max max-col 1- min >col ;
 : mv      ( r c-- ) norm-col norm-row row nt-line ;
@@ -29,4 +29,4 @@ block-sz var work
 : >row/col ( r c-- ) >col >row ;
 21 26 thru
 : ed ( -- ) ed-init rl cls ed-loop ;
-: edit ( blk-- ) >blk ed ;
+

--- a/block-020.fth
+++ b/block-020.fth
@@ -3,14 +3,14 @@
  5 load ( screen )
 10 load ( vars )
 15 load ( blocks )
-: blk        40 @c ;  : >blk          40 !c ;
-: rows       41 @c ;  : >rows         41 !c ;  : max-row  rows 1- ;
-: cols       42 @c ;  : >cols         42 !c ;  : max-col  cols 1- ;
-: row        43 @c ;  : >row          43 !c ;  : row++ row 1+ >row ;
-: col        44 @c ;  : >col          44 !c ;  : col++ col 1+ >col ;
-: ed-mode    45 @c ;  : >ed-mode      45 !c ;
-: show?      46 @c ;  : show!       1 46 !c ;  : shown   0 46 !c ;
-: dirty?     47 @c ;  : dirty show! 1 47 !c ;  : clean   0 47 !c ;
+: blk        40 wc@ ;  : >blk          40 wc! ;
+: rows       41 wc@ ;  : >rows         41 wc! ;  : max-row  rows 1- ;
+: cols       42 wc@ ;  : >cols         42 wc! ;  : max-col  cols 1- ;
+: row        43 wc@ ;  : >row          43 wc! ;  : row++ row 1+ >row ;
+: col        44 wc@ ;  : >col          44 wc! ;  : col++ col 1+ >col ;
+: ed-mode    45 wc@ ;  : >ed-mode      45 wc! ;
+: show?      46 wc@ ;  : show!       1 46 wc! ;  : shown   0 46 wc! ;
+: dirty?     47 wc@ ;  : dirty show! 1 47 wc! ;  : clean   0 47 wc! ;
 : block-sz rows cols * ;
 32 >rows   100 >cols
 block-sz var block

--- a/block-020.fth
+++ b/block-020.fth
@@ -29,4 +29,4 @@ block-sz var work
 : >row/col ( r c-- ) >col >row ;
 21 26 thru
 : ed ( -- ) ed-init rl cls ed-loop ;
-
+: edit ( blk-- ) >blk ed ;

--- a/block-021.fth
+++ b/block-021.fth
@@ -4,16 +4,16 @@
 : work->block work >a  block >t  0 dup >row/col
     begin  @a+ ?dup  if0 t2 exit then  t1  row rows < while t2 ;
 : clear-block ( addr-- ) block-sz 32 fill ;
-: ed-load work clear-block  block clear-block
+: rl ( reload block ) work clear-block  block clear-block
     block-fn fopen-rb ?dup if
         >t work block-sz t@ fread drop t> fclose
     then work->block clean show! 0 dup >row/col ;
-: ed-goto ( blk-- ) >blk ed-load ;
+: >ed ( blk-- ) >blk rl ;
 : normal-mode  0 ;  : insert-mode  1 ;  : replace-mode  2 ;  : quit-mode 99 ;
 : normal-mode?  normal-mode  ed-mode = ;  : normal-mode!  normal-mode  >ed-mode ;
 : insert-mode?  insert-mode  ed-mode = ;  : insert-mode!  insert-mode  >ed-mode ;
 : replace-mode? replace-mode ed-mode = ;  : replace-mode! replace-mode >ed-mode ;
-: quit?         quit-mode    ed-mode = ;  : quit!         quit-mode    >ed-mode ;
+: quit?         quit-mode    ed-mode = ;  : q!            quit-mode    >ed-mode ;
 : .mode space normal-mode? if ." -normal-" exit then
     red insert-mode?  if ." -insert-" then
     replace-mode? if ." -replace-" then

--- a/block-024.fth
+++ b/block-024.fth
@@ -17,13 +17,14 @@
   again ;
 : q dirty? if ." (use q! to quit without saving)" exit then q! ;
 : wq w q! ;
-: do-cmd ->cmd ':' emit clr-eol cur-on
-    p1 accept ->cmd clr-eol
-    p1 c@ if p1 outer then ;
+: do-cmd ->cmd ':' emit cur-on p1 accept ->cmd p1 outer ;
 : yank-line  p2 row 0 >pos  s-cpy drop ;
 : put-line   insert-line  row 0 >pos p2 s-cpy drop dirty ;
 : next-blk   w  blk 1- 0 max >ed ;
 : prev-blk   w  blk 1+       >ed ;
+
+
+
 
 
 

--- a/block-024.fth
+++ b/block-024.fth
@@ -1,9 +1,8 @@
 : ->file ( fh-- ) (output-fp) ! ;  : ->stdout 0 ->file ;
 : write-row  p1 i 0 >pos s-cpy s-rtrim ztype 10 emit ;
 : write-block rows for write-row next ;
-: save-block  dirty? if0 exit then
-    block-fn fopen-wb ?dup
-    if >t t@ ->file write-block t> fclose clean ->stdout then ;
+: w  dirty? if block-fn fopen-wb ?dup
+    if >t t@ ->file write-block t> fclose clean ->stdout then then ;
 : bs 8 emit ;
 : del-ch ( -- ) y@ x@ < if x- 0 !x bs space bs then ;
 : app-ch ( ch-- ) !x+ 0 !x emit ;
@@ -16,17 +15,17 @@
     a@ 8 =   a@ 127 =  or  if del-ch then
     a@ printable? if a@ app-ch then
   again ;
-: ?quit dirty? if ." (use q! to quit without saving)" exit then quit! ;
+: q dirty? if ." (use q! to quit without saving)" exit then q! ;
+: wq w q! ;
 : do-cmd ->cmd ':' emit clr-eol cur-on
     p1 accept ->cmd clr-eol
-    p1 z" q"  s-eq  if  ?quit exit  then
-    p1 z" q!" s-eq  if  quit! exit  then
-    p1 z" wq" s-eq  if  save-block quit!  exit   then
-    p1 z" w"  s-eq  if  save-block clean  exit   then
-    p1 c@ '!' = if p1 1+ outer exit then
-    p1 z" rl" s-eq  if  ed-load then ;
+    p1 c@ if p1 outer then ;
 : yank-line  p2 row 0 >pos  s-cpy drop ;
 : put-line   insert-line  row 0 >pos p2 s-cpy drop dirty ;
-: next-blk   save-block  blk 1- 0 max >blk  ed-load ;
-: prev-blk   save-block  blk 1+       >blk  ed-load ;
+: next-blk   w  blk 1- 0 max >ed ;
+: prev-blk   w  blk 1+       >ed ;
+
+
+
+
 

--- a/block-025.fth
+++ b/block-025.fth
@@ -18,14 +18,14 @@
     a@  32 = if mv-rt exit then            a@ '_' = if 0 >col exit then
     a@ 'q' = if 0  8 mv exit then          a@ 'R' = if replace-mode! exit then
     a@ 'Q' = if 0 -8 mv exit then          a@ 'i' = if insert-mode!  exit then
-    a@ ':' = if do-cmd  exit then          a@ '!' = if cls show!     exit then
+    a@ ':' = if do-cmd  exit then          a@ '#' = if cls show!     exit then
     a@ 'r' = if replace-one exit then      a@ 'C' = if row col clear-eol exit then
     a@ 'x' = if delete-char exit then      a@ 'X' = if mv-lt delete-char exit then
     a@ 'J' = if join-lines  exit then      a@ 'Y' = if yank-line       exit then
     a@ 'p' = if put-line    exit then      a@ 'P' = if mv-dn put-line  exit then
     a@ '$' = if mv-eol exit then           a@ 'A' = if mv-eol insert-mode! exit then
     a@ '-' = if next-blk exit then         a@ '+' = if prev-blk exit then
-    a@ 'D' = if yank-line delete-line exit then
+    a@ 'D' = if yank-line delete-line exit then   a@ '!' = if ->cmd p1 outer exit then
     a@ 'b' = if 32 insert-char mv-lt  exit then
     a@ 'o' = if mv-dn insert-line replace-mode!  exit then
     a@ 'O' = if       insert-line replace-mode!  exit then ;

--- a/block-025.fth
+++ b/block-025.fth
@@ -18,7 +18,7 @@
     a@  32 = if mv-rt exit then            a@ '_' = if 0 >col exit then
     a@ 'q' = if 0  8 mv exit then          a@ 'R' = if replace-mode! exit then
     a@ 'Q' = if 0 -8 mv exit then          a@ 'i' = if insert-mode!  exit then
-    a@ ':' = if do-cmd  exit then          a@ '!' = if show!         exit then
+    a@ ':' = if do-cmd  exit then          a@ '!' = if cls show!     exit then
     a@ 'r' = if replace-one exit then      a@ 'C' = if row col clear-eol exit then
     a@ 'x' = if delete-char exit then      a@ 'X' = if mv-lt delete-char exit then
     a@ 'J' = if join-lines  exit then      a@ 'Y' = if yank-line       exit then

--- a/block-026.fth
+++ b/block-026.fth
@@ -2,9 +2,9 @@
 : t2 green '|' emit white ;
 : footer ->foot blk ."  -Block %d- "
     bl dirty? if drop '*' then emit
-    col 1+ row 1+ ."  (%d,%d) " .mode clr-eol ;
+    col 1+ row 1+ ."  (%d,%d) " .mode
+    p1 ."   (cmd: %S)" clr-eol ;
 : show cur-off 1 1 ->rc t1 rows for i 0 >pos t2 ztype t2 cr next t1 shown ;
-
 : ?show show? if show then footer ;
 : ed-init 0 >row 0 >col normal-mode! clean cur-block ;
 : ed-loop begin ?show ->cur vkey cur-off a! ed-key quit? until  ->cmd cur-on ;

--- a/bootstrap.fth
+++ b/bootstrap.fth
@@ -1,15 +1,15 @@
 : \ 0 >in @ w! ; immediate
 : ->code code + ;
 : ->dict dict + ;
-: here  (here)  @c ;
-: last  (last)  @c ;
-: base@ base    @c ;
-: base! base    !c ;
+: here  (here)  wc@ ;
+: last  (last)  wc@ ;
+: base@ base    wc@ ;
+: base! base    wc! ;
 : vhere (vhere) @ ;
 : allot vhere + (vhere) ! ;
-: 0sp  0 (dsp)  !c ;
-: 0rsp 0 (rsp)  !c ;
-: , here  dup 1+ (here) !c !c ;
+: 0sp  0 (dsp)  wc! ;
+: 0rsp 0 (rsp)  wc! ;
+: , here  dup 1+ (here) wc! wc! ;
 : create addword ; immediate
 : const  addword here cell wc-sz / - wc-sz * ->code ! (exit) , ; immediate
 : does> (jmp) , r> , ;
@@ -23,8 +23,8 @@
 : if  (jmpz)  , here 0 , ; immediate
 : if0 (jmpnz) , here 0 , ; immediate
 : -if (njmpz) , here 0 , ; immediate
-: else (jmp) , here swap 0 , here swap !c ; immediate
-: then here swap !c ; immediate
+: else (jmp) , here swap 0 , here swap wc! ; immediate
+: then here swap wc! ; immediate
 : ( begin
     >in @ c@
     dup  0= if drop exit then
@@ -70,12 +70,12 @@
 : (.) <# #s #> ztype ;
 : . (.) space ;
 : .version version <# # # #. # # #. #s #> ztype ;
-: .s '(' emit space (dsp) @c 1- ?dup
+: .s '(' emit space (dsp) wc@ 1- ?dup
     if for i 1+ cells dstk + @ . next then ')' emit ;
 : cr 13 emit 10 emit ;
 : tab 9 emit ;
 : ?  @ . ;
-: ->xt     l@ ;
+: ->xt     d@ ;
 : ->flags  wc-sz + c@ ;
 : ->len    wc-sz + 1+ c@ ;
 : ->name   wc-sz + 2+ ;
@@ -92,8 +92,8 @@
           dup ->name ztype tab a@+ 9 > if cr 0 a! then de-sz +
       next drop adrop ;
 cell var vh
-: marker here 20 !c last 21 !c vhere vh ! ;
-: forget 20 @c (here) !c 21 @c (last) !c vh @ (vhere) ! ;
+: marker here 20 wc! last 21 wc! vhere vh ! ;
+: forget 20 wc@ (here) wc! 21 wc@ (last) wc! vh @ (vhere) ! ;
 : fopen-rt ( fn--fh )  z" rt" fopen ;
 : fopen-rb ( fn--fh )  z" rb" fopen ;
 : fopen-wb ( fn--fh )  z" wb" fopen ;

--- a/c4.c
+++ b/c4.c
@@ -86,7 +86,7 @@ DE_T tmpWords[10];
 	X(QKEY,    "?key",      0, push(qKey()); ) \
 	X(COLON,   ":",         0, addWord(0); state=1; ) \
 	X(SEMI,    ";",         1, comma(EXIT); state=0; ) \
-	X(LITC,    "LIT,",      0, t=pop(); compileNum(t); ) \
+	X(LITC,    "lit,",      0, t=pop(); compileNum(t); ) \
 	X(NEXTWD,  "next-wd",   0, push(nextWord()); ) \
 	X(IMMED,   "immediate", 0, { DE_T *dp = (DE_T*)&vars[last]; dp->fl=_IMMED; } ) \
 	X(INLINE,  "inline",    0, { DE_T *dp = (DE_T*)&vars[last]; dp->fl=_INLINE; } ) \

--- a/c4.c
+++ b/c4.c
@@ -86,7 +86,6 @@ DE_T tmpWords[10];
 	X(QKEY,    "?key",      0, push(qKey()); ) \
 	X(COLON,   ":",         0, addWord(0); state=1; ) \
 	X(SEMI,    ";",         1, comma(EXIT); state=0; ) \
-	X(COMMA,   ",",         0, t=pop(); comma((wc_t)t); ) \
 	X(LITC,    "LIT,",      0, t=pop(); compileNum(t); ) \
 	X(LCOMMA,  "l,",        0, commaCell(pop()); ) \
 	X(NEXTWD,  "next-wd",   0, push(nextWord()); ) \

--- a/c4.c
+++ b/c4.c
@@ -87,7 +87,6 @@ DE_T tmpWords[10];
 	X(COLON,   ":",         0, addWord(0); state=1; ) \
 	X(SEMI,    ";",         1, comma(EXIT); state=0; ) \
 	X(LITC,    "LIT,",      0, t=pop(); compileNum(t); ) \
-	X(LCOMMA,  "l,",        0, commaCell(pop()); ) \
 	X(NEXTWD,  "next-wd",   0, push(nextWord()); ) \
 	X(IMMED,   "immediate", 0, { DE_T *dp = (DE_T*)&vars[last]; dp->fl=_IMMED; } ) \
 	X(INLINE,  "inline",    0, { DE_T *dp = (DE_T*)&vars[last]; dp->fl=_INLINE; } ) \

--- a/c4.c
+++ b/c4.c
@@ -36,12 +36,12 @@ DE_T tmpWords[10];
 	X(OVER,    "over",      0, t=NOS; push(t); ) \
 	X(FET,     "@",         0, TOS = fetchCell(TOS); ) \
 	X(FET1,    "c@",        0, TOS = *(byte *)TOS; ) \
-	X(LFET32,  "l@",        0, TOS = fetch32(TOS); ) \
-	X(FETC,    "@c",        0, TOS = code[(wc_t)TOS]; ) \
+	X(LFET32,  "d@",        0, TOS = fetch32(TOS); ) \
+	X(FETC,    "wc@",       0, TOS = code[(wc_t)TOS]; ) \
 	X(STO,     "!",         0, t=pop(); n=pop(); storeCell(t, n); ) \
 	X(STO1,    "c!",        0, t=pop(); n=pop(); *(byte*)t=(byte)n; ) \
-	X(STO32,   "l!",        0, t=pop(); n=pop(); store32(t, n); ) \
-	X(STOC,    "!c",        0, t=pop(); n=pop(); code[(wc_t)t] = (wc_t)n; ) \
+	X(STO32,   "d!",        0, t=pop(); n=pop(); store32(t, n); ) \
+	X(STOC,    "wc!",       0, t=pop(); n=pop(); code[(wc_t)t] = (wc_t)n; ) \
 	X(ADD,     "+",         0, t=pop(); TOS += t; ) \
 	X(SUB,     "-",         0, t=pop(); TOS -= t; ) \
 	X(MUL,     "*",         0, t=pop(); TOS *= t; ) \

--- a/c4.h
+++ b/c4.h
@@ -25,7 +25,6 @@
 #define NUM_BITS          0xE0000000
 #define NUM_MASK          0x1FFFFFFF
 #define CODE_SZ           0x00020000
-#define DICT_SZ          (10000*sizeof(DE_T))
 #define VARS_SZ           4*1024*1024
 
 #define STK_SZ            63

--- a/c4.h
+++ b/c4.h
@@ -17,7 +17,7 @@
 #include <stdint.h>
 #include <time.h>
 
-#define VERSION   20241021
+#define VERSION   20241022
 #define _SYS_LOAD_
 
 #define WC_T              uint32_t

--- a/c4.h
+++ b/c4.h
@@ -17,7 +17,7 @@
 #include <stdint.h>
 #include <time.h>
 
-#define VERSION   20241023
+#define VERSION   20241024
 #define _SYS_LOAD_
 
 #define WC_T              uint32_t

--- a/c4.h
+++ b/c4.h
@@ -17,7 +17,7 @@
 #include <stdint.h>
 #include <time.h>
 
-#define VERSION   20241022
+#define VERSION   20241023
 #define _SYS_LOAD_
 
 #define WC_T              uint32_t

--- a/sys-load.c
+++ b/sys-load.c
@@ -9,15 +9,15 @@ void sys_load() {
     outer(": \\ 0 >in @ c! ; immediate");
     outer(": ->code code + ;");
     outer(": ->dict dict + ;");
-    outer(": here  (here)  @c ;");
-    outer(": last  (last)  @c ;");
-    outer(": base@ base    @c ;");
-    outer(": base! base    !c ;");
+    outer(": here  (here)  wc@ ;");
+    outer(": last  (last)  wc@ ;");
+    outer(": base@ base    wc@ ;");
+    outer(": base! base    wc! ;");
     outer(": vhere (vhere) @ ;");
     outer(": allot vhere + (vhere) ! ;");
-    outer(": 0sp  0 (dsp)  !c ;");
-    outer(": 0rsp 0 (rsp)  !c ;");
-    outer(": , here  dup 1+ (here) !c !c ;");
+    outer(": 0sp  0 (dsp)  wc! ;");
+    outer(": 0rsp 0 (rsp)  wc! ;");
+    outer(": , here  dup 1+ (here) wc! wc! ;");
 
     outer(": const  addword inline lit, (exit) , ;");
     outer(": create vhere addword inline vhere lit, ;");
@@ -33,10 +33,10 @@ void sys_load() {
     outer(": -if (njmpz) , here 0 , ; immediate");
     outer(": if  (jmpz)  , here 0 , ; immediate");
     outer(": if0 (jmpnz) , here 0 , ; immediate");
-    outer(": else (jmp) , here swap 0 , here swap !c ; immediate");
-    outer(": then here swap !c ; immediate");
-    outer(": [ 0 state !c ; immediate");
-    outer(": ] 1 state !c ;");
+    outer(": else (jmp) , here swap 0 , here swap wc! ; immediate");
+    outer(": then here swap wc! ; immediate");
+    outer(": [ 0 state wc! ; immediate");
+    outer(": ] 1 state wc! ;");
 
     outer(": ( begin");
     outer("    >in @ c@");
@@ -91,13 +91,13 @@ void sys_load() {
     outer(": .version version <# # # #. # # #. #s #> ztype ;");
     outer(": ?  @ . ;");
 
-    outer(": .s '(' emit space (dsp) @c 1- ?dup");
+    outer(": .s '(' emit space (dsp) wc@ 1- ?dup");
     outer("    if for i 1+ cells dstk + @ . next then ')' emit ;");
 
-    outer(": [[ vhere >t here >t 1 state !c ;");
-    outer(": ]] (exit) , 0 state !c t@ (here) !c t> >r t> (vhere) ! ; immediate");
+    outer(": [[ vhere >t here >t 1 state wc! ;");
+    outer(": ]] (exit) , 0 state wc! t@ (here) wc! t> >r t> (vhere) ! ; immediate");
 
-    outer(": ->xt     l@ ;");
+    outer(": ->xt     d@ ;");
     outer(": ->flags  wc-sz + c@ ;");
     outer(": ->len    wc-sz + 1+ c@ ;");
     outer(": ->name   wc-sz + 2+ ;");
@@ -116,9 +116,9 @@ void sys_load() {
     outer("      next drop adrop ;");
 
     outer("cell var vh");
-    outer(": marker here 20 !c last 21 !c vhere vh ! ;");
-    outer(": forget 20 @c (here) !c 21 @c (last) !c vh @ (vhere) ! ;");
-    outer(": fgl last dup de-sz + (last) !c dict + l@ (here) !c ;");
+    outer(": marker here 20 wc! last 21 wc! vhere vh ! ;");
+    outer(": forget 20 wc@ (here) wc! 21 wc@ (last) wc! vh @ (vhere) ! ;");
+    outer(": fgl last dup de-sz + (last) wc! dict + d@ (here) wc! ;");
     outer(": fopen-rt ( fn--fh )  z\" rt\" fopen ;");
     outer(": fopen-rb ( fn--fh )  z\" rb\" fopen ;");
     outer(": fopen-wb ( fn--fh )  z\" wb\" fopen ;");

--- a/sys-load.c
+++ b/sys-load.c
@@ -8,7 +8,7 @@ void sys_load() {
 void sys_load() {
     outer(": \\ 0 >in @ c! ; immediate");
     outer(": ->code code + ;");
-    outer(": ->dict dict + ;");
+    outer(": ->vars vars + ;");
     outer(": here  (here)  wc@ ;");
     outer(": last  (last)  wc@ ;");
     outer(": base@ base    wc@ ;");
@@ -75,7 +75,7 @@ void sys_load() {
     outer(": @t- t@- c@ ;    : !t- t@- c! ;");
     outer(": t+  t@+ drop ;  : t-  t@- drop ;");
 
-    outer(": <#   ( n1--n2 )  dict 64 + >t 0 t@ c! dup 0 < >a abs ;");
+    outer(": <#   ( n1--n2 )  vhere 256 + >t 0 t@ c! dup 0 < >a abs ;");
     outer(": #c   ( c-- )     t- t@ c! ;");
     outer(": #.   ( -- )      '.' #c ;");
     outer(": #n   ( n-- )     dup 9 > if 7 + then '0' + #c ;");
@@ -101,9 +101,9 @@ void sys_load() {
     outer(": ->flags  wc-sz + c@ ;");
     outer(": ->len    wc-sz + 1+ c@ ;");
     outer(": ->name   wc-sz + 2+ ;");
-    outer(": dict-end dict dict-sz + 1- ;");
+    outer(": dict-end vars vars-sz + 1- ;");
 
-    outer(": words last ->dict >a 0 >t 0 >r");
+    outer(": words last ->vars >a 0 >t 0 >r");
     outer("    begin");
     outer("      a@ ->name ztype r@ 1+ r!");
     outer("      a@ ->len  7 > if t+ then");
@@ -111,14 +111,14 @@ void sys_load() {
     outer("      t@+ 8 > if cr 0 t! else tab then");
     outer("      a@ de-sz + a! a@ dict-end <");
     outer("    while tdrop adrop r> .\"  (%d words)\" ;");
-    outer(": words-n ( n-- )  0 >a last ->dict swap for");
+    outer(": words-n ( n-- )  0 >a last ->vars swap for");
     outer("          dup ->name ztype tab a@+ 9 > if cr 0 a! then de-sz +");
     outer("      next drop adrop ;");
 
     outer("cell var vh");
     outer(": marker here 20 wc! last 21 wc! vhere vh ! ;");
     outer(": forget 20 wc@ (here) wc! 21 wc@ (last) wc! vh @ (vhere) ! ;");
-    outer(": fgl last dup de-sz + (last) wc! dict + d@ (here) wc! ;");
+    outer(": fgl last dup de-sz + (last) wc! vars + d@ (here) wc! ;");
     outer(": fopen-rt ( fn--fh )  z\" rt\" fopen ;");
     outer(": fopen-rb ( fn--fh )  z\" rb\" fopen ;");
     outer(": fopen-wb ( fn--fh )  z\" wb\" fopen ;");

--- a/sys-load.c
+++ b/sys-load.c
@@ -75,7 +75,8 @@ void sys_load() {
     outer(": @t- t@- c@ ;    : !t- t@- c! ;");
     outer(": t+  t@+ drop ;  : t-  t@- drop ;");
 
-    outer(": <#   ( n1--n2 )  vhere 256 + >t 0 t@ c! dup 0 < >a abs ;");
+    outer("100 var #buf");
+    outer(": <#   ( n1--n2 )  #buf 99 + >t 0 t@ c! dup 0 < >a abs ;");
     outer(": #c   ( c-- )     t- t@ c! ;");
     outer(": #.   ( -- )      '.' #c ;");
     outer(": #n   ( n-- )     dup 9 > if 7 + then '0' + #c ;");

--- a/sys-load.c
+++ b/sys-load.c
@@ -80,8 +80,8 @@ void sys_load() {
     outer(": #.   ( -- )      '.' #c ;");
     outer(": #n   ( n-- )     dup 9 > if 7 + then '0' + #c ;");
     outer(": #    ( n1--n2 )  base@ /mod swap #n ;");
-    outer(": #s   ( n-- )     begin # -while drop ;");
-    outer(": #>   ( --str )   a> if '-' #c then t> ;");
+    outer(": #s   ( n-- )     begin # -while ;");
+    outer(": #>   ( --str )   drop a> if '-' #c then t> ;");
     outer(": (.) <# #s #> ztype ;");
     outer(": . (.) 32 emit ;");
 


### PR DESCRIPTION
Use wc@/wc! instead of @c/!c
Use d@/d! instead of l@/l!
Merge DICT and VARS
Move drop from #s to #>
Remove "," primitive
Remove unused "l," primitive
Version 2024.10.24